### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY requirements.txt /opt/
 
 RUN  set -ex \
 	\
-	&& apt-get update && apt-get install -y --no-install-recommends curl wget xz-utils vim \
+	&& apt-get update && apt-get install -y curl gcc wget xz-utils vim \
         && pip install --disable-pip-version-check --no-cache-dir -r /opt/requirements.txt \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixed Dockerfile to install gcc due to the latest python slim-buster base image requirement