### PR TITLE
Added support to open pkcs#8 key

### DIFF
--- a/fb_recover_keys.py
+++ b/fb_recover_keys.py
@@ -84,7 +84,10 @@ def main():
                 mobile_key_pass = getpass.getpass(prompt='Please enter mobile recovery RSA private key passphrase:')
 
     with open(args.key, 'r') as _key:
-        if 'ENCRYPTED' in _key.readlines()[1]:
+        key_file = _key.readlines();
+        if 'ENCRYPTED' in key_file[0]:
+            key_pass = getpass.getpass(prompt='Please enter recovery RSA private key passphrase:')
+        elif 'ENCRYPTED' in key_file[1]:
             key_pass = getpass.getpass(prompt='Please enter recovery RSA private key passphrase:')
         else:
             key_pass = None


### PR DESCRIPTION
Following recent update of OpenSSL to v3.0 in Ubuntu. The RSA private key is generated in PKCS#8 format which is not supported by the script when trying to get the RSA passphrase. Added another if that supports PKCS#8 and backward compatible to older versions of OpenSSL.